### PR TITLE
Improved release script, see issue #14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
-release.zip
+
 
 # dependencies
 /node_modules
@@ -12,6 +12,7 @@ release.zip
 
 # production
 /build
+/releases
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "port",
+  "name": "feldspar",
   "version": "0.1.0",
   "private": true,
   "homepage": ".",
@@ -31,8 +31,7 @@
     "start:app": "react-scripts start",
     "start": "concurrently 'npm run start:py' 'npm run start:app'",
     "build": "npm run build:py && npm run build:app && npm run build:css",
-    "archive": "cd build && zip -r ../release.zip .",
-    "release": "npm run build && npm run archive",
+    "release": "npm run build && ./release.sh $npm_package_name",
     "test": "react-scripts test",
     "lint": "npm run fix:ts"
   },

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,8 @@
+#!/bin/bash 
+NAME=$1
+mkdir -p releases
+NR=$(find ./releases -type f | wc -l | xargs)
+NR=$(($NR + 1))
+TIMESTAMP=$(date '+%Y-%m-%d')
+cd build
+zip -r ../releases/${NAME}_${TIMESTAMP}_${NR}.zip .


### PR DESCRIPTION
- Releases are created in a folder "releases"
- The format of the release filename is: <npm_package_name>_<date>_<release_count>.zip
- Release count is the total amount of releases locally available + 1
- This solution does not (yet) work on windows
