### PR TITLE
Donations after approved don't go back to pyodide, but are send to the bridge

### DIFF
--- a/src/framework/processing/py/port/api/props.py
+++ b/src/framework/processing/py/port/api/props.py
@@ -114,10 +114,12 @@ class PropsUIPromptConsentForm:
     """Tables to be shown to the participant prior to donation
 
     Attributes:
+        id: A unique string to identify the table after donation.
         tables: a list of tables
         meta_tables: a list of optional tables, for example for logging data
     """
 
+    id: str
     tables: list[PropsUIPromptConsentFormTable]
     meta_tables: list[PropsUIPromptConsentFormTable]
     description: Optional[Translatable] = None
@@ -139,6 +141,7 @@ class PropsUIPromptConsentForm:
     def toDict(self):
         dict = {}
         dict["__type__"] = "PropsUIPromptConsentForm"
+        dict["id"] = self.id
         dict["tables"] = self.translate_tables()
         dict["metaTables"] = self.translate_meta_tables()
         dict["description"] = self.description and self.description.toDict()

--- a/src/framework/processing/py/port/script.py
+++ b/src/framework/processing/py/port/script.py
@@ -52,11 +52,8 @@ def process(sessionId):
 
     # STEP 2: ask for consent
     meta_data.append(("debug", f"{key}: prompt consent"))
-    prompt = prompt_consent(data, meta_data)
+    prompt = prompt_consent(f"{sessionId}-{key}", data, meta_data)
     consent_result = yield render_donation_page(prompt)
-    if consent_result.__type__ == "PayloadJSON":
-        meta_data.append(("debug", f"{key}: donate consent data"))
-        yield donate(f"{sessionId}-{key}", consent_result.value)
     if consent_result.__type__ == "PayloadFalse":   
         value = json.dumps('{"status" : "donation declined"}')
         yield donate(f"{sessionId}-{key}", value)
@@ -135,7 +132,7 @@ def extract_file(zipfile_ref, filename):
         return "invalid"
     
 
-def prompt_consent(data, meta_data):
+def prompt_consent(id, data, meta_data):
 
     table_title = props.Translatable({
         "en": "Zip file contents",
@@ -156,7 +153,7 @@ def prompt_consent(data, meta_data):
 
     meta_frame = pd.DataFrame(meta_data, columns=["type", "message"])
     meta_table = props.PropsUIPromptConsentFormTable("log_messages", log_title, meta_frame)
-    return props.PropsUIPromptConsentForm(tables, [meta_table])
+    return props.PropsUIPromptConsentForm(id, tables, [meta_table])
 
 
 def donate(key, json_string):

--- a/src/framework/types/commands.ts
+++ b/src/framework/types/commands.ts
@@ -43,7 +43,8 @@ export type PayloadResolved =
   PayloadTrue |
   PayloadString |
   PayloadFile |
-  PayloadJSON
+  PayloadJSON |
+  PayloadDonate
 
 export interface PayloadVoid {
   __type__: 'PayloadVoid'
@@ -71,6 +72,12 @@ export interface PayloadJSON {
 }
 export function isPayloadJSON (arg: any): arg is PayloadJSON {
   return isInstanceOf<PayloadJSON>(arg, 'PayloadJSON', ['value'])
+}
+
+export interface PayloadDonate {
+  __type__: 'PayloadDonate'
+  value: string
+  key: string
 }
 
 export type Command =

--- a/src/framework/types/prompts.ts
+++ b/src/framework/types/prompts.ts
@@ -57,11 +57,12 @@ export interface PropsUIPromptConsentForm {
   description?: Text
   donateQuestion?: Text
   donateButton?: Text
+  id: string
   tables: PropsUIPromptConsentFormTable[]
   metaTables: PropsUIPromptConsentFormTable[]
 }
 export function isPropsUIPromptConsentForm (arg: any): arg is PropsUIPromptConsentForm {
-  return isInstanceOf<PropsUIPromptConsentForm>(arg, 'PropsUIPromptConsentForm', ['tables', 'metaTables'])
+  return isInstanceOf<PropsUIPromptConsentForm>(arg, 'PropsUIPromptConsentForm', ['id', 'tables', 'metaTables'])
 }
 
 export interface PropsUIPromptConsentFormTable {

--- a/src/framework/visualisation/react/ui/prompts/consent_form.tsx
+++ b/src/framework/visualisation/react/ui/prompts/consent_form.tsx
@@ -23,7 +23,7 @@ export const ConsentForm = (props: Props): JSX.Element => {
   const tablesOut = React.useRef<Array<PropsUITable & TableContext>>(tablesIn.current)
   const [waiting, setWaiting] = React.useState<boolean>(false)
 
-  const { locale, resolve } = props
+  const { locale, resolve, id } = props
   const cancelButton = Translator.translate(cancelButtonLabel, props.locale)
 
   function rowCell (dataFrame: any, column: string, row: number): PropsUITableCell {
@@ -104,7 +104,7 @@ export const ConsentForm = (props: Props): JSX.Element => {
   function handleDonate (): void {
     setWaiting(true)
     const value = serializeConsentData()
-    resolve?.({ __type__: 'PayloadJSON', value })
+    resolve?.({ __type__: 'PayloadDonate', "value": value, "key": id })
   }
 
   function handleCancel (): void {


### PR DESCRIPTION
# Fixes this issue

https://github.com/d3i-infra/data-donation-task/issues/24

# Why?

In case of a donation, the donation is not send back to pyodide, but its send to the bridge. Which makes more sense, because the round trip is not necessary (and can cause problems).

So instead of:

```
extraction > consent_form > worker_engine > py_worker >  worker_engine > bridge
```

its now:

```
extraction > consent_form > worker_engine > bridge
```


# Changes

Major changes are in `worker_engine.tsx`, `handleRunClycle` can now intercept responses and `script.py` changed, it's self explanatory but good to realize!


