### PR TITLE
made pandas dataframe optional to prevent serialization

### DIFF
--- a/src/framework/processing/py/port/api/props.py
+++ b/src/framework/processing/py/port/api/props.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional, TypedDict
+from typing import Optional, TypedDict, Dict, Any
 
 import pandas as pd
 
@@ -98,14 +98,20 @@ class PropsUIPromptConsentFormTable:
 
     id: str
     title: Translatable
-    data_frame: pd.DataFrame
+    data_frame: pd.DataFrame | Dict[str, Dict[str, Any]]
+
+    def translate_data_frame(self):
+        if isinstance(self.data_frame, pd.DataFrame):
+            return self.data_frame.to_json()
+        else:
+            return self.data_frame
 
     def toDict(self):
         dict = {}
         dict["__type__"] = "PropsUIPromptConsentFormTable"
         dict["id"] = self.id
         dict["title"] = self.title.toDict()
-        dict["data_frame"] = self.data_frame.to_json()
+        dict["data_frame"] = self.translate_data_frame()
         return dict
 
 

--- a/src/framework/visualisation/react/ui/prompts/consent_form.tsx
+++ b/src/framework/visualisation/react/ui/prompts/consent_form.tsx
@@ -72,7 +72,7 @@ export const ConsentForm = (props: Props): JSX.Element => {
     const id = tableData.id
     const title = Translator.translate(tableData.title, props.locale)
     const deletedRowCount = 0
-    const dataFrame = JSON.parse(tableData.data_frame)
+    const dataFrame = loadDataFrame(tableData.data_frame)
     const headCells = columnNames(dataFrame).map((column: string) => headCell(dataFrame, column))
     const head: PropsUITableHead = { __type__: 'PropsUITableHead', cells: headCells }
     const body: PropsUITableBody = { __type__: 'PropsUITableBody', rows: rows(dataFrame) }
@@ -167,6 +167,13 @@ export const ConsentForm = (props: Props): JSX.Element => {
       </div>
     </>
   )
+}
+
+function loadDataFrame(dataFrame: any) {
+  if (typeof dataFrame === "string") {
+      return JSON.parse(dataFrame)
+  } 
+  return dataFrame;
 }
 
 const donateQuestionLabel = new TextBundle()


### PR DESCRIPTION
# Solves

https://github.com/d3i-infra/data-donation-task/issues/23

# Solution

Make data frames optional so no serialization has to take place. Current code remains working.

The change is small, but the effects on performance are large in case the dataframes become extremely large.
This sometimes an issue for tiktok, when people have watch history going into the million.

# To test

In script.py use for example:

```
data_frame = { 
    "variable_x": {"0":1, "1":3},
    "variable_y": {"0": "appel", "1": "peer"},
}
```
