### PR TITLE
confirm prompt should not have a continue options

### DIFF
--- a/packages/feldspar/src/framework/types/prompts.ts
+++ b/packages/feldspar/src/framework/types/prompts.ts
@@ -20,10 +20,9 @@ export interface PropsUIPromptConfirm {
   __type__: 'PropsUIPromptConfirm'
   text: Text
   ok: Text
-  cancel: Text
 }
 export function isPropsUIPromptConfirm (arg: any): arg is PropsUIPromptConfirm {
-  return isInstanceOf<PropsUIPromptConfirm>(arg, 'PropsUIPromptConfirm', ['text', 'ok', 'cancel'])
+  return isInstanceOf<PropsUIPromptConfirm>(arg, 'PropsUIPromptConfirm', ['text', 'ok'])
 }
 
 export interface PropsUIPromptFileInput {

--- a/packages/feldspar/src/framework/visualization/react/ui/prompts/confirm.tsx
+++ b/packages/feldspar/src/framework/visualization/react/ui/prompts/confirm.tsx
@@ -4,21 +4,16 @@ import { PropsUIPromptConfirm } from '../../../../types/prompts'
 import { Translator } from '../../../../translator'
 import { BodyLarge } from '../elements/text'
 import { PrimaryButton } from '../elements/button'
-import { JSX } from 'react'
 import React from 'react'
 
 type Props = Weak<PropsUIPromptConfirm> & ReactFactoryContext
 
 export const Confirm = (props: Props): JSX.Element => {
   const { resolve } = props
-  const { text, ok, cancel } = prepareCopy(props)
+  const { text, ok } = prepareCopy(props)
 
   function handleOk (): void {
     resolve?.({ __type__: 'PayloadTrue', value: true })
-  }
-
-  function handleCancel (): void {
-    resolve?.({ __type__: 'PayloadFalse', value: false })
   }
 
   return (
@@ -26,7 +21,6 @@ export const Confirm = (props: Props): JSX.Element => {
       <BodyLarge text={text} margin='mb-4' />
       <div className='flex flex-row gap-4'>
         <PrimaryButton label={ok} onClick={handleOk} color='text-grey1 bg-tertiary' />
-        <PrimaryButton label={cancel} onClick={handleCancel} color='text-white bg-primary' />
       </div>
     </>
   )
@@ -35,13 +29,11 @@ export const Confirm = (props: Props): JSX.Element => {
 interface Copy {
   text: string
   ok: string
-  cancel: string
 }
 
-function prepareCopy ({ text, ok, cancel, locale }: Props): Copy {
+function prepareCopy ({ text, ok, locale }: Props): Copy {
   return {
     text: Translator.translate(text, locale),
     ok: Translator.translate(ok, locale),
-    cancel: Translator.translate(cancel, locale)
   }
 }

--- a/packages/python/port/api/props.py
+++ b/packages/python/port/api/props.py
@@ -70,19 +70,16 @@ class PropsUIPromptConfirm:
     Attributes:
         text: message to display
         ok: message to display if the user wants to try again
-        cancel: message to display if the user wants to continue regardless
     """
 
     text: Translatable
     ok: Translatable
-    cancel: Translatable
 
     def toDict(self):
         dict = {}
         dict["__type__"] = "PropsUIPromptConfirm"
         dict["text"] = self.text.toDict()
         dict["ok"] = self.ok.toDict()
-        dict["cancel"] = self.cancel.toDict()
         return dict
 
 


### PR DESCRIPTION
# The problem

If input validation fails the confirm prompt is triggered (see also script.py). Participant should not be allowed to continue.

Participants can now click continue, and will register as completed, as they have completed the data share task. They will receive an incentive, although they were not able to provide a valid ddp.

The continue was only there, to prevent participant from getting stuck, because Next did not implement a "back or close" button. Next back then did not keep track of completion status

# Solution

remove the continue option from the confirm prompt







