### PR TITLE
chore: allow any version upgrades for all npm packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
     "release": "./release.sh"
   },
   "devDependencies": {
-    "@playwright/test": "^1.51.0",
-    "@types/node": "^22.13.10",
-    "concurrently": "^8.2.2",
-    "husky": "^9.1.7",
-    "nodemon": "^3.1.10"
+    "@playwright/test": "*",
+    "@types/node": "*",
+    "concurrently": "*",
+    "husky": "*",
+    "nodemon": "*"
   },
   "dependencies": {
-    "fdir": "^6.4.3"
+    "fdir": "*"
   }
 }

--- a/packages/data-collector/package.json
+++ b/packages/data-collector/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "homepage": ".",
   "dependencies": {
-    "@eyra/feldspar": "^0.1.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-scripts": "5.0.1"
+    "@eyra/feldspar": "*",
+    "react": "*",
+    "react-dom": "*",
+    "react-scripts": "*"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/packages/feldspar/package.json
+++ b/packages/feldspar/package.json
@@ -19,14 +19,14 @@
         "clean": "rm -rf dist node_modules"
     },
     "peerDependencies": {
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
+        "react": "*",
+        "react-dom": "*",
         "tslib": "*",
         "typescript": "*"
     },
     "dependencies": {
-        "@types/lodash": "^4.17.14",
-        "lodash": "^4.17.21"
+        "@types/lodash": "*",
+        "lodash": "*"
     },
     "exports": {
         ".": {


### PR DESCRIPTION
## Summary
- Remove all version constraints to allow Dependabot to update to any newer version
- Replace version specifiers with "*" for all dependencies

## Changes
- Updated root package.json
- Updated packages/feldspar/package.json  
- Updated packages/data-collector/package.json

This will allow Dependabot to propose updates for any newer versions without restriction.