### PR TITLE
Potential fix for code scanning alert: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ jobs:
 
   tagged_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
Fix for [https://github.com/eyra/feldspar/security/code-scanning/4](https://github.com/eyra/feldspar/security/code-scanning/4)

To address the issue, an explicit `permissions` block should be added to the `tagged_release` job, specifying the least privilege required for the job to execute successfully. Since the job involves using `softprops/action-gh-release` to create a release with specific files, the `contents: write` permission is necessary. Other permissions should remain unset to minimize potential security risks.
