### PR TITLE
Pin release tag to workflow commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,3 +77,4 @@ jobs:
           files: ${{ env.RELEASE_NAME }}
           prerelease: ${{ env.BRANCH != 'main' }}
           generate_release_notes: true
+          target_commitish: ${{ github.sha }}

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -52,6 +52,45 @@ When an out-of-memory error occurs in the browser:
 - The task will **not** receive a green checkmark
 - No error data is captured or sent to the server
 
+## Logging and Error Monitoring
+
+As part of ongoing improvements to the reliability and stability of Feldspar, error and diagnostic logging may be enabled.
+
+### What is logged
+
+Feldspar may collect and forward technical log messages, including:
+- JavaScript errors (browser level)
+- Framework-level errors
+- Python runtime errors (if enabled)
+
+These logs are used solely for debugging and improving the platform.
+
+### Important: Potential inclusion of personal data
+
+Although logs are intended to contain only technical information, log messages may unintentionally include personal data.
+
+This can occur in two ways:
+- When developers explicitly log messages that include user-provided input or data
+- When runtime errors or exceptions include data in their error messages or stack traces
+
+### Data handling
+
+- Logs are processed within the Next platform infrastructure
+- Logs are not used for research purposes
+- Logs are only accessed for debugging and system improvement
+
+### Responsibilities
+
+Script developers and researchers setting up the data donation study are responsible for:
+- Avoiding logging of personal data in their scripts
+- Handling exceptions in a way that prevents unintended inclusion of personal data in log messages
+
+### Roadmap
+
+The following features are on the Feldspar development roadmap:
+- More granular logging controls (per layer: browser, framework, Python)
+- Options to disable logging entirely for privacy-sensitive studies
+
 ## Recommendations
 
 To maximize successful data donations:
@@ -61,10 +100,6 @@ To maximize successful data donations:
 3. **Test with representative data sizes** before deploying to participants
 4. **Monitor server logs** for donation errors
 5. **Consider participant device diversity** when designing data extraction scripts
-
-## Upcoming Improvements
-
-**Milestone 7** will introduce client-side error monitoring, sending JavaScript and Python errors from Feldspar to the Next server. This will improve visibility into client-side failures, though out-of-memory crashes will still result in data loss.
 
 ## Questions
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,10 @@ When your data donation application is ready for deployment:
 
 To use the release in the Next platform, add a "Donate task" and select the generated ZIP file as the "Flow application".
 
+## Important Disclaimer
+
+Please review the [disclaimer](./disclaimer.md) in this repository for important information about technical limitations, logging behavior, and data handling considerations.
+
 ## Funding
 
 Feldspar is part of the Port program for data donation and has been funded by the UU, PDI-SSH ([D3i project](https://datadonation.eu/)), and [Eyra](https://www.eyra.co/).

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ To use the release in the Next platform, add a "Donate task" and select the gene
 
 ## Important Disclaimer
 
-Please review the [disclaimer](./disclaimer.md) in this repository for important information about technical limitations, logging behavior, and data handling considerations.
+Please review the [disclaimer](./DISCLAIMER.md) in this repository for important information about technical limitations, logging behavior, and data handling considerations.
 
 ## Funding
 


### PR DESCRIPTION
## Summary

`softprops/action-gh-release@v2` defaults `target_commitish` to the repo's default branch when not provided. Effect: release tags produced by the `Release` workflow for `milestone/*` and `feature/*` pushes ended up pointing at the default branch's HEAD rather than the commit that was actually tested and built. Auto-generated release notes then missed everything on the release branch.

This adds the one line the action needs to anchor the tag to the actual build commit:

```yaml
target_commitish: \${{ github.sha }}
```

For pushes to the default branch itself the behaviour is unchanged (the two are the same commit). The fix only changes the outcome for non-default-branch releases.

Discovered while cutting a hotfix release on the `eyra/2025-cambridge-instagram` fork, which has the same workflow.

## Test plan

- [x] Pre-commit Playwright e2e suite passes
- [ ] Next push to a `milestone/*` or `feature/*` branch produces a release whose tag points to the pushed commit (verify via `gh api /repos/eyra/feldspar/git/refs/tags/<tag>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)