### PR TITLE
Add workerLog forwarding and FlushLogs sentinel

### DIFF
--- a/packages/data-collector/public/py_worker.js
+++ b/packages/data-collector/public/py_worker.js
@@ -29,10 +29,43 @@ onmessage = (event) => {
   }
 };
 
+let cycleCount = 0;
+
 function runCycle(payload) {
+  const cycleId = ++cycleCount;
+  const payloadType = (payload && payload.__type__) || "null";
   console.log("[ProcessingWorker] runCycle " + JSON.stringify(payload));
+  self.postMessage({
+    eventType: "workerLog",
+    level: "debug",
+    message: `[Worker] runCycle #${cycleId} starting, payload=${payloadType}`,
+  });
+  let scriptEvent;
   try {
     scriptEvent = pyScript.send(payload);
+  } catch (error) {
+    console.error("[ProcessingWorker] Error in pyScript.send:", error);
+    self.postMessage({
+      eventType: "error",
+      error: error.toString(),
+      stack: error.stack || "",
+    });
+    return;
+  }
+  let commandType = "unknown";
+  try {
+    if (scriptEvent && typeof scriptEvent.get === "function") {
+      commandType = scriptEvent.get("__type__") || "unknown";
+    }
+  } catch (e) {
+    commandType = `unreadable (${e.message})`;
+  }
+  self.postMessage({
+    eventType: "workerLog",
+    level: "debug",
+    message: `[Worker] runCycle #${cycleId} got command=${commandType}`,
+  });
+  try {
     self.postMessage({
       eventType: "runCycleDone",
       scriptEvent: scriptEvent.toJs({
@@ -41,7 +74,7 @@ function runCycle(payload) {
       }),
     });
   } catch (error) {
-    console.error("[ProcessingWorker] Error in runCycle:", error);
+    console.error("[ProcessingWorker] Error in toJs/postMessage:", error);
     self.postMessage({
       eventType: "error",
       error: error.toString(),

--- a/packages/feldspar/src/framework/processing/worker_engine.test.ts
+++ b/packages/feldspar/src/framework/processing/worker_engine.test.ts
@@ -1,0 +1,90 @@
+import WorkerProcessingEngine from './worker_engine'
+import { Logger, LogLevel } from '../logging'
+import { Command, Response } from '../types/commands'
+import { CommandHandler } from '../types/modules'
+
+class FakeWorker {
+  onmessage: ((event: any) => void) | null = null
+  onerror: ((error: any) => void) | null = null
+  postMessage = (): void => {}
+  terminate = (): void => {}
+  addEventListener = (): void => {}
+  removeEventListener = (): void => {}
+  dispatchEvent = (): boolean => true
+}
+
+class FakeLogger implements Logger {
+  entries: Array<{ level: LogLevel, message: string, context?: Record<string, unknown> }> = []
+  flushCount = 0
+  log (level: LogLevel, message: string, context?: Record<string, unknown>): void {
+    this.entries.push({ level, message, context })
+  }
+  flush (): void {
+    this.flushCount++
+  }
+}
+
+class FakeHandler implements CommandHandler {
+  async onCommand (_command: Command): Promise<Response> {
+    return { __type__: 'Response', command: _command, payload: { __type__: 'PayloadVoid', value: undefined } }
+  }
+}
+
+function makeEngine (): { engine: WorkerProcessingEngine, logger: FakeLogger, worker: FakeWorker } {
+  const worker = new FakeWorker()
+  const logger = new FakeLogger()
+  const engine = new WorkerProcessingEngine('s1', worker as unknown as Worker, new FakeHandler(), logger)
+  return { engine, logger, worker }
+}
+
+describe('WorkerProcessingEngine.handleEvent', () => {
+  it('routes workerLog events through logger with the provided level', () => {
+    const { engine, logger } = makeEngine()
+    engine.handleEvent({ data: { eventType: 'workerLog', level: 'debug', message: 'starting cycle' } })
+    expect(logger.entries).toContainEqual({ level: 'debug', message: 'starting cycle', context: undefined })
+  })
+
+  it('falls back to info for unknown workerLog levels', () => {
+    const { engine, logger } = makeEngine()
+    engine.handleEvent({ data: { eventType: 'workerLog', level: 'banana', message: 'oops' } })
+    expect(logger.entries).toContainEqual({ level: 'info', message: 'oops', context: undefined })
+  })
+
+  it('accepts each valid LogLevel without falling back', () => {
+    const { engine, logger } = makeEngine()
+    const levels: LogLevel[] = ['debug', 'info', 'warn', 'error']
+    for (const level of levels) {
+      engine.handleEvent({ data: { eventType: 'workerLog', level, message: `at-${level}` } })
+    }
+    expect(logger.entries.map(e => e.level)).toEqual(levels)
+  })
+
+  it('routes worker error events as error log with stack context', () => {
+    const { engine, logger } = makeEngine()
+    engine.handleEvent({ data: { eventType: 'error', error: 'KeyError', stack: 'trace' } })
+    expect(logger.entries).toContainEqual({
+      level: 'error',
+      message: 'Python error: KeyError',
+      context: { stack: 'trace' },
+    })
+  })
+
+  it('flushes the logger after handling each event', () => {
+    const { engine, logger } = makeEngine()
+    expect(logger.flushCount).toBe(0)
+    engine.handleEvent({ data: { eventType: 'workerLog', level: 'info', message: 'one' } })
+    expect(logger.flushCount).toBe(1)
+    engine.handleEvent({ data: { eventType: 'error', error: 'boom', stack: '' } })
+    expect(logger.flushCount).toBe(2)
+  })
+
+  it('logs a warn for an unsupported event type', () => {
+    const { engine, logger } = makeEngine()
+    engine.handleEvent({ data: { eventType: 'mysteryEvent' } })
+    expect(logger.entries).toContainEqual({
+      level: 'warn',
+      message: 'Received unsupported worker event: mysteryEvent',
+      context: undefined,
+    })
+  })
+})

--- a/packages/feldspar/src/framework/processing/worker_engine.ts
+++ b/packages/feldspar/src/framework/processing/worker_engine.ts
@@ -1,6 +1,12 @@
 import { CommandHandler } from '../types/modules'
 import { CommandSystemEvent, isCommand, Response } from '../types/commands'
-import { Logger } from '../logging'
+import { Logger, LogLevel } from '../logging'
+
+const VALID_LOG_LEVELS: LogLevel[] = ['debug', 'info', 'warn', 'error']
+
+function toLogLevel (value: unknown): LogLevel {
+  return VALID_LOG_LEVELS.includes(value as LogLevel) ? (value as LogLevel) : 'info'
+}
 
 export default class WorkerProcessingEngine {
   sessionId: String
@@ -61,6 +67,10 @@ export default class WorkerProcessingEngine {
 
       case 'error':
         this.logger?.log('error', `Python error: ${event.data.error}`, { stack: event.data.stack })
+        break
+
+      case 'workerLog':
+        this.logger?.log(toLogLevel(event.data.level), event.data.message)
         break
 
       default:

--- a/packages/python/port/api/commands.py
+++ b/packages/python/port/api/commands.py
@@ -57,3 +57,13 @@ class CommandSystemExit:
         dict["code"] = self.code
         dict["info"] = self.info
         return dict
+
+
+class FlushLogs:
+    """Sentinel to signal that the log queue should be flushed.
+
+    Yield this from a generator to flush any accumulated logs to the client
+    before continuing processing. This allows logs to be sent incrementally
+    during long-running operations.
+    """
+    pass

--- a/packages/python/port/main.py
+++ b/packages/python/port/main.py
@@ -2,7 +2,7 @@ import logging
 from collections import deque
 from collections.abc import Generator
 from port.script import process
-from port.api.commands import CommandSystemExit
+from port.api.commands import CommandSystemExit, FlushLogs
 from port.api.file_utils import AsyncFileAdapter
 from port.api.logging import LogForwardingHandler
 
@@ -19,16 +19,23 @@ class ScriptWrapper(Generator):
         logger.addHandler(LogForwardingHandler(self.queue))
 
     def send(self, data):
-        if not self.queue:
+        while True:
+            if self.queue:
+                return self.queue.popleft()
+
             if data and getattr(data, '__type__') == "PayloadFile":
                 data.value = AsyncFileAdapter(data.value)
             try:
                 command = self.script.send(data)
             except StopIteration:
                 return CommandSystemExit(0, "End of script").toDict()
-            self.queue.append(command.toDict())
 
-        return self.queue.popleft()
+            if command is FlushLogs:
+                data = None
+                continue
+
+            self.queue.append(command.toDict())
+            data = None
 
     def throw(self, type=None, value=None, traceback=None):
         raise StopIteration

--- a/packages/python/tests/test_script_wrapper.py
+++ b/packages/python/tests/test_script_wrapper.py
@@ -1,0 +1,103 @@
+"""Tests for ScriptWrapper FlushLogs sentinel handling and log queue draining."""
+
+import logging
+import sys
+import types
+from pathlib import Path
+
+# Add packages/python to sys.path so the `port` package resolves.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# Stub `port.script` and `port.api.file_utils` before importing `port.main`.
+# Their real modules pull in pandas (via props.py) and Pyodide-only `js`
+# respectively, neither of which is needed for testing the wrapper.
+_fake_script = types.ModuleType("port.script")
+_fake_script.process = lambda *_: iter([])
+sys.modules["port.script"] = _fake_script
+
+_fake_file_utils = types.ModuleType("port.api.file_utils")
+_fake_file_utils.AsyncFileAdapter = lambda value: value
+sys.modules["port.api.file_utils"] = _fake_file_utils
+
+from port.main import ScriptWrapper  # noqa: E402
+from port.api.commands import CommandUIRender, FlushLogs  # noqa: E402
+
+
+class _StubPage:
+    """Stand-in for a CommandUIRender's page argument."""
+
+    def toDict(self):
+        return {"__type__": "Page", "value": "stub"}
+
+
+def _ui_command():
+    return CommandUIRender(_StubPage())
+
+
+def test_flushlogs_sentinel_does_not_become_a_command():
+    """Yielding FlushLogs from the script must not surface as a command."""
+
+    def script():
+        yield FlushLogs
+        yield _ui_command()
+
+    wrapper = ScriptWrapper(script())
+    assert wrapper.send(None)["__type__"] == "CommandUIRender"
+
+
+def test_flushlogs_sentinel_drains_pending_logs_first():
+    """Logs queued before FlushLogs must drain before the next command."""
+    logger_name = "port.script.test_flushlogs_drain"
+
+    def script():
+        logging.getLogger(logger_name).info("first")
+        yield FlushLogs
+        yield _ui_command()
+
+    wrapper = ScriptWrapper(script())
+    wrapper.add_log_handler(logger_name)
+
+    first = wrapper.send(None)
+    assert first["__type__"] == "CommandSystemLog"
+    assert first["level"] == "info"
+    assert first["message"] == "first"
+
+    second = wrapper.send(None)
+    assert second["__type__"] == "CommandUIRender"
+
+
+def test_logs_emitted_after_flushlogs_arrive_on_next_send():
+    """Logs emitted after the sentinel surface only on the following send call."""
+    logger_name = "port.script.test_flushlogs_subsequent"
+
+    def script():
+        yield FlushLogs
+        logging.getLogger(logger_name).warning("after")
+        yield _ui_command()
+
+    wrapper = ScriptWrapper(script())
+    wrapper.add_log_handler(logger_name)
+
+    # First send: queue is empty, script runs to FlushLogs (no logs yet),
+    # loops, runs to next yield which logs then yields the command.
+    # Wrapper appends command to queue and returns the log first.
+    first = wrapper.send(None)
+    assert first["__type__"] == "CommandSystemLog"
+    assert first["level"] == "warn"
+    assert first["message"] == "after"
+
+    second = wrapper.send(None)
+    assert second["__type__"] == "CommandUIRender"
+
+
+def test_stopiteration_yields_systemexit():
+    """When the script generator returns, wrapper emits a CommandSystemExit dict."""
+
+    def script():
+        if False:
+            yield
+
+    wrapper = ScriptWrapper(script())
+    result = wrapper.send(None)
+    assert result["__type__"] == "CommandSystemExit"
+    assert result["code"] == 0


### PR DESCRIPTION
## Summary

Backports two foundational pieces that were written downstream (in `2025-cambridge-instagram`, commits `513d97c` and `3c1fe7f`) but never made it back to feldspar. Without them every fork has to re-discover the runCycle observability story and the incremental log-flush pattern, and any reconciliation against a fork that implemented one of them produces avoidable merge conflicts.

## What's in here

**Worker telemetry** (`worker_engine.ts` + `py_worker.js`)
- `py_worker.js` emits `workerLog` events around `runCycle` (start, with payload type; end, with the resulting command type) and splits the previously blanket try/catch into `pyScript.send` vs `toJs/postMessage`, so a frozen session points at the boundary that hung.
- `worker_engine.ts` handles the new `workerLog` event by routing through the existing `Logger` interface — same `LogForwarder` pipeline as everything else, no parallel `CommandSystemLog` channel. `toLogLevel()` narrows the runtime string from the worker so a malformed level degrades to `info` rather than failing typecheck.

**Log flush sentinel** (`commands.py` + `main.py`)
- `FlushLogs` is a sentinel class scripts can yield to actively drain logs during long-running operations, rather than waiting for the next user interaction to round-trip a command.
- `ScriptWrapper.send` becomes a loop: drain any queued logs first, otherwise advance the script; if the script yielded the sentinel, loop instead of returning it as a command.

## Tests

New, since Cambridge shipped these without coverage:
- Python (`test_script_wrapper.py`): sentinel handling, log ordering across the sentinel, `StopIteration` → `CommandSystemExit`.
- JS (`worker_engine.test.ts`): `workerLog` routes with the supplied level, falls back to `info` on garbage levels, error events still produce error logs with stack context, the logger flushes after every event, unsupported events warn through the logger.

Suite results on this branch: Python 13/13, JS 12/12. Pre-commit Playwright e2e 4/4.

## Test plan

- [ ] CI runs the Python suite (now includes `test_script_wrapper.py`)
- [ ] CI runs the JS suite (now includes `worker_engine.test.ts`)
- [ ] Existing e2e tests still pass (verified locally via pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)