### PR TITLE
Fix sys.modules pollution in test_script_wrapper

### DIFF
--- a/packages/python/port/api/file_utils.py
+++ b/packages/python/port/api/file_utils.py
@@ -6,7 +6,10 @@ synchronous Python file operations, avoiding the need to copy entire
 files into Pyodide's virtual filesystem.
 """
 
-import js
+try:
+    import js  # Only available in Pyodide
+except ImportError:
+    js = None  # Running outside Pyodide (e.g., in tests)
 
 
 class AsyncFileAdapter:

--- a/packages/python/tests/test_script_wrapper.py
+++ b/packages/python/tests/test_script_wrapper.py
@@ -2,25 +2,13 @@
 
 import logging
 import sys
-import types
 from pathlib import Path
 
 # Add packages/python to sys.path so the `port` package resolves.
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-# Stub `port.script` and `port.api.file_utils` before importing `port.main`.
-# Their real modules pull in pandas (via props.py) and Pyodide-only `js`
-# respectively, neither of which is needed for testing the wrapper.
-_fake_script = types.ModuleType("port.script")
-_fake_script.process = lambda *_: iter([])
-sys.modules["port.script"] = _fake_script
-
-_fake_file_utils = types.ModuleType("port.api.file_utils")
-_fake_file_utils.AsyncFileAdapter = lambda value: value
-sys.modules["port.api.file_utils"] = _fake_file_utils
-
-from port.main import ScriptWrapper  # noqa: E402
-from port.api.commands import CommandUIRender, FlushLogs  # noqa: E402
+from port.main import ScriptWrapper
+from port.api.commands import CommandUIRender, FlushLogs
 
 
 class _StubPage:


### PR DESCRIPTION
## Summary

- `test_script_wrapper.py` was replacing `sys.modules["port.script"]` and `sys.modules["port.api.file_utils"]` at module level, poisoning the module cache for all test files collected in the same pytest session
- `file_utils.py` had a bare `import js` that failed outside Pyodide — the downstream repos (Cambridge, Cornell) had already added a `try/except` guard; this brings feldspar in line

## Test plan

- [ ] `poetry run pytest tests/` passes (13/13) in feldspar
- [ ] No stubs in `sys.modules` means downstream test suites with more test files won't hit import errors from the poisoned cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)