### PR TITLE
Fix compatibility with vite v8 and TypeScript v6

### DIFF
--- a/packages/data-collector/vite.config.ts
+++ b/packages/data-collector/vite.config.ts
@@ -36,9 +36,9 @@ export default defineConfig({
     sourcemap: true,
     rollupOptions: {
       output: {
-        manualChunks: {
-          vendor: ['react', 'react-dom'],
-          feldspar: ['@eyra/feldspar']
+        manualChunks: (id) => {
+          if (id.includes('react-dom') || id.includes('react')) return 'vendor'
+          if (id.includes('@eyra/feldspar')) return 'feldspar'
         }
       }
     }

--- a/packages/feldspar/tsconfig.json
+++ b/packages/feldspar/tsconfig.json
@@ -15,7 +15,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "types": ["jest"]
+    "types": ["jest", "node"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/feldspar/tsconfig.json
+++ b/packages/feldspar/tsconfig.json
@@ -14,7 +14,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["jest"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

Fixes CI failures on the pending major-version dependency PRs (#691, #708, #690).

- **vite v8**: `manualChunks` in `vite.config.ts` no longer accepts a plain object — converted to a function
- **TypeScript v6**: no longer auto-infers `@types/jest`, added `"jest"` and `"node"` to `tsconfig.json` `types` field

## Test plan

- [ ] Build passes without warnings
- [ ] JS unit tests pass
- [ ] E2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)