### PR TITLE
Add SafeData for crash-resistant JSON access

### DIFF
--- a/packages/python/port/safe_data.py
+++ b/packages/python/port/safe_data.py
@@ -1,0 +1,562 @@
+"""Crash-resistant access to parsed JSON data with typed accessors and error tracking.
+
+Wraps Python objects produced by JSON parsing so extraction scripts can
+pull typed values without worrying about missing keys, nulls, or
+unexpected types. Every type mismatch is logged and recorded; callers
+can check `had_errors()` to decide whether the extracted data is
+trustworthy.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import IO, Any, Callable, Optional, Sequence, Type, TypeVar, Union
+
+Path = Union[str, Sequence[str]]
+"""A path is either a dotted string ("user.name") or a sequence of
+literal segments (["user.name"] = one key whose name contains a dot)."""
+
+logger = logging.getLogger("safedata")
+
+T = TypeVar("T")
+
+ErrorHook = Callable[[str, str, Any, str], None]
+"""Hook signature: (path, expected_type, actual_value, reason)."""
+
+_MAX_REPR_LEN = 80
+
+
+class _Root:
+    """Shared per-tree state: error list and optional hook target.
+
+    Every SafeData in a tree (including empty fallbacks produced by
+    failed accessors) holds a reference to the same _Root, so errors
+    anywhere propagate to had_errors() on the root.
+    """
+
+    __slots__ = ("errors",)
+
+    def __init__(self) -> None:
+        self.errors: list[tuple[str, str, Any, str]] = []
+
+
+def _truncate_repr(value: Any) -> str:
+    r = repr(value)
+    return r if len(r) <= _MAX_REPR_LEN else r[: _MAX_REPR_LEN - 3] + "..."
+
+
+class SafeData:
+    """Wraps a parsed JSON-derived Python object for crash-free typed access.
+
+    Construct via `SafeData.parse_json(text_or_file)` or
+    `SafeData.wrap(obj)`. The tree is walked once and every nested dict
+    or list is replaced with a SafeData that knows its dotted path from
+    the root. Dotted paths use string keys for dicts and integer
+    indices for lists: e.g. `get_str("users.0.name")`.
+
+    The root may be a dict, a list, or a scalar. For a list root, call
+    `get_list_of(type_)` without a key, or navigate into it with dotted
+    indices.
+
+    Variant shapes: the scalar getters and `get_dict`/`get_list` accept
+    several paths and return the first that resolves to the requested
+    type, so a value that may live under different keys (or different
+    nesting) can be read in one call:
+
+        data.get_str("user.name", "account.profile.fullName", default="")
+
+    A path that is missing or wrong-typed is tried silently and falls
+    through to the next; an error is recorded only if every path fails.
+
+    Dotted vs literal keys: a path given as a string is split on ".".
+    If a JSON key itself contains a dot, pass the path as a sequence of
+    literal segments instead — the elements are used verbatim, with no
+    splitting:
+
+        data.get_str("user.name")       # descend: user -> name
+        data.get_str(["user.name"])     # one literal key "user.name"
+        data.get_str(["a.b"], "x.y")    # literal "a.b", else path x.y
+    """
+
+    _error_hook: Optional[ErrorHook] = None
+
+    __slots__ = ("_raw", "_path", "_root", "_poisoned")
+
+    def __init__(self, raw: Any, path: str, root: _Root, poisoned: bool = False) -> None:
+        self._raw = raw
+        self._path = path
+        self._root = root
+        self._poisoned = poisoned
+
+    @classmethod
+    def set_error_hook(cls, hook: Optional[ErrorHook]) -> None:
+        """Install a class-level hook called on every type error.
+
+        Pass None to clear. The hook fires in addition to logging, not
+        instead of it. One hook per process; later calls replace earlier.
+        """
+        cls._error_hook = hook
+
+    @classmethod
+    def parse_json(cls, source: Union[str, bytes, IO]) -> "SafeData":
+        """Parse JSON from a string, bytes, or a file-like object and wrap the result.
+
+        A parse failure (malformed JSON, I/O error) returns an empty
+        SafeData with had_errors() == True. The script never sees a
+        JSONDecodeError or IOError.
+        """
+        root = _Root()
+        try:
+            if isinstance(source, (str, bytes)):
+                obj = json.loads(source)
+            else:
+                obj = json.load(source)
+        except (json.JSONDecodeError, OSError, ValueError, TypeError) as e:
+            reason = f"parse failed: {e}"
+            root.errors.append(("", "json", source, reason))
+            logger.warning("safedata: parse_json failed: %s", e)
+            cls._fire_hook("", "json", source, reason)
+            return cls(None, "", root, poisoned=True)
+        return cls._build(obj, "", root)
+
+    @classmethod
+    def wrap(cls, obj: Any) -> "SafeData":
+        """Wrap an already-parsed object.
+
+        Accepts dict, list, or scalar. Scalars are retrievable via raw().
+        """
+        return cls._build(obj, "", _Root())
+
+    @classmethod
+    def _build(cls, obj: Any, path: str, root: _Root) -> "SafeData":
+        """Wrap a parsed object as the root SafeData.
+
+        Nested dicts are walked and each becomes a SafeData. Lists stay
+        as Python lists but their dict elements become SafeData.
+        Scalars remain raw.
+        """
+        if isinstance(obj, dict):
+            wrapped: Any = {k: cls._build_value(v, _join(path, k), root) for k, v in obj.items()}
+        elif isinstance(obj, list):
+            wrapped = [cls._build_value(v, _join(path, str(i)), root) for i, v in enumerate(obj)]
+        else:
+            wrapped = obj
+        return cls(wrapped, path, root)
+
+    @classmethod
+    def _build_value(cls, obj: Any, path: str, root: _Root) -> Any:
+        """Recursively wrap a dict into SafeData; lists keep their shape
+        but have nested dicts wrapped; scalars stay raw."""
+        if isinstance(obj, dict):
+            return cls._build(obj, path, root)
+        if isinstance(obj, list):
+            return [cls._build_value(v, _join(path, str(i)), root) for i, v in enumerate(obj)]
+        return obj
+
+    def raw(self) -> Any:
+        """Return the underlying object (dict, list, or scalar).
+
+        For wrapped dicts/lists, returns the container with child
+        SafeData nodes still wrapping nested dicts/lists.
+        """
+        return self._raw
+
+    def path(self) -> str:
+        """Dotted path from the root. Empty string at the root."""
+        return self._path
+
+    def had_errors(self) -> bool:
+        """True if any error occurred on this node or any descendant.
+
+        Propagates to the root: checking the root after extraction tells
+        you whether anything in the whole tree went sideways.
+        """
+        return bool(self._root.errors)
+
+    def get_errors(self) -> list[tuple[str, str, Any, str]]:
+        """Return a copy of all recorded errors as (path, expected, actual, reason).
+
+        Always reflects every error in the tree, not just errors below
+        this node — the list lives on the root and is shared.
+        """
+        return list(self._root.errors)
+
+    # --- Iteration -------------------------------------------------------
+
+    def __iter__(self):
+        """Iterate elements of a list node or keys of a dict node.
+
+        - List node: yields each element as a `SafeData`. Scalar
+          elements get wrapped on the fly so callers can mix scalar and
+          object elements in a polymorphic list:
+
+              for elem in data.get_list("payload"):
+                  if isinstance(elem.raw(), str):
+                      ...
+                  else:
+                      name = elem.get_str("name")
+
+        - Dict node: yields the keys (str), matching Python's dict
+          iteration convention.
+        - Scalar / non-iterable: raises TypeError.
+        """
+        if isinstance(self._raw, list):
+            for i, element in enumerate(self._raw):
+                if isinstance(element, SafeData):
+                    yield element
+                else:
+                    yield SafeData(element, _join(self._path, str(i)), self._root, poisoned=self._poisoned)
+            return
+        if isinstance(self._raw, dict):
+            yield from self._raw.keys()
+            return
+        raise TypeError(f"SafeData at {self._path or '<root>'} is not iterable (got {type(self._raw).__name__})")
+
+    def __len__(self) -> int:
+        """Length of a list or dict node. Raises TypeError on scalars."""
+        if isinstance(self._raw, (list, dict)):
+            return len(self._raw)
+        raise TypeError(f"SafeData at {self._path or '<root>'} has no length (got {type(self._raw).__name__})")
+
+    # --- Typed accessors -------------------------------------------------
+    #
+    # Each scalar getter accepts one or more dotted paths. Paths are
+    # tried in order and the first that resolves to the requested type
+    # wins. A path that is missing or holds the wrong type is NOT an
+    # error on its own — it just falls through to the next candidate. An
+    # error (logged + recorded) is raised only if EVERY candidate fails,
+    # so a successful fallback keeps had_errors() clean. Call with no
+    # path to coerce this node's own value (useful on list elements).
+
+    def get_str(self, *keys: "Path", default: str = "") -> str:
+        """Get a string from the first matching path. Coerces non-None scalars via str()."""
+        return self._resolve_scalar(keys, "str", _coerce_str, default)
+
+    def get_int(self, *keys: "Path", default: int = 0) -> int:
+        """Get an int from the first matching path. Accepts int, integral float, parseable str."""
+        return self._resolve_scalar(keys, "int", _coerce_int, default)
+
+    def get_float(self, *keys: "Path", default: float = 0.0) -> float:
+        """Get a float from the first matching path. Accepts int, float, parseable str."""
+        return self._resolve_scalar(keys, "float", _coerce_float, default)
+
+    def get_bool(self, *keys: "Path", default: bool = False) -> bool:
+        """Get a bool from the first matching path. Strict: only accepts actual bool values."""
+        return self._resolve_scalar(keys, "bool", _coerce_bool, default)
+
+    def _resolve_scalar(
+        self,
+        keys: tuple["Path", ...],
+        expected: str,
+        coerce: Callable[[Any], tuple[bool, Any]],
+        default: T,
+    ) -> T:
+        """Try each path in `keys`, returning the first that coerces.
+
+        With no keys, coerce this node's own value. Records exactly one
+        error if every candidate fails; that error names all tried paths.
+        """
+        candidates = keys if keys else (None,)
+        last_value: Any = None
+        last_path = self._path
+        for key in candidates:
+            if key is None:
+                value, full_path, ok = self._raw, self._path, True
+            else:
+                value, full_path, ok = self._navigate(key)
+            last_value, last_path = value, full_path
+            if not ok:
+                continue
+            matched, result = coerce(value)
+            if matched:
+                return result
+        err_path, reason = self._coalesce_error_info(candidates, last_path)
+        return self._error(err_path, expected, last_value, reason, default)
+
+    def get_list(self, *keys: "Path", default: Optional["SafeData"] = None) -> "SafeData":
+        """Get a nested SafeData wrapping a list — useful for polymorphic lists.
+
+        Accepts one or more paths; the first that resolves to a list
+        wins (others are tried silently). Iterate the result to get one
+        SafeData per element regardless of element type. For homogeneous
+        lists where you want a plain Python list back, use
+        `get_list_of(type_, key)` instead.
+
+        If no candidate path holds a list, records one error and returns
+        an empty poisoned SafeData so iteration is empty and downstream
+        access stays quiet.
+        """
+        candidates = keys if keys else (None,)
+        last_value: Any = None
+        last_path = self._path
+        for key in candidates:
+            if key is None:
+                value, full_path, ok = self, self._path, True
+            else:
+                value, full_path, ok = self._navigate(key)
+            last_value, last_path = value, full_path
+            if not ok:
+                continue
+            container = value._raw if isinstance(value, SafeData) else value
+            if isinstance(container, list):
+                return SafeData(container, full_path, self._root)
+        err_path, reason = self._coalesce_error_info(candidates, last_path)
+        self._error(err_path, "list", last_value, reason, None)
+        return default if default is not None else SafeData([], err_path, self._root, poisoned=True)
+
+    def get_dict(self, *keys: "Path", default: Optional["SafeData"] = None) -> "SafeData":
+        """Get a nested SafeData wrapping a dict.
+
+        Accepts one or more paths; the first that resolves to a dict
+        wins (others are tried silently). If none does, records one
+        error and returns an empty SafeData marked as "poisoned" —
+        further access on it returns defaults silently, avoiding a
+        cascade of follow-up errors for the same root cause.
+        """
+        candidates = keys if keys else (None,)
+        last_value: Any = None
+        last_path = self._path
+        for key in candidates:
+            if key is None:
+                value, full_path, ok = self, self._path, True
+            else:
+                value, full_path, ok = self._navigate(key)
+            last_value, last_path = value, full_path
+            if not ok:
+                continue
+            if isinstance(value, SafeData) and isinstance(value._raw, dict):
+                return value
+        err_path, reason = self._coalesce_error_info(candidates, last_path)
+        self._error(err_path, "dict", last_value, reason, None)
+        return default if default is not None else SafeData({}, err_path, self._root, poisoned=True)
+
+    def get_list_of(
+        self,
+        type_: Type[T],
+        key: Optional["Path"] = None,
+        default: Optional[list] = None,
+    ) -> list[T]:
+        """Get a list filtered to elements of the given type.
+
+        If `key` is None, this node itself must be a list (used at the
+        root of a list document, or after navigating into a list). If
+        `key` is given, the list is fetched from that key/path first.
+
+        Elements failing the type check are dropped and each drop is
+        logged with its index in the path (e.g. "tags[3]"). Allowed
+        types: str, int, float, bool, SafeData. Raw dict and list are
+        intentionally not allowed — use SafeData for nested objects so
+        downstream access stays crash-free.
+        """
+        if type_ not in (str, int, float, bool, SafeData):
+            raise TypeError(
+                f"get_list_of: type_ must be one of str, int, float, bool, SafeData; got {type_!r}"
+            )
+
+        if key is None:
+            container = self._raw
+            full_path = self._path
+        else:
+            value, full_path, ok = self._navigate(key)
+            if not ok:
+                self._error(full_path, "list", None, "missing or unreachable", None)
+                return list(default) if default is not None else []
+            container = value._raw if isinstance(value, SafeData) else value
+
+        if not isinstance(container, list):
+            self._error(full_path, "list", container, "not a list", None)
+            return list(default) if default is not None else []
+
+        out: list[T] = []
+        for i, element in enumerate(container):
+            elem_path = f"{full_path}[{i}]" if full_path else f"[{i}]"
+            unwrapped = element._raw if isinstance(element, SafeData) else element
+
+            if type_ is SafeData:
+                if isinstance(element, SafeData) and isinstance(element._raw, dict):
+                    out.append(element)  # type: ignore[arg-type]
+                else:
+                    self._error(elem_path, "SafeData", unwrapped, "element is not a dict", None)
+                continue
+
+            if type_ is bool:
+                if isinstance(unwrapped, bool):
+                    out.append(unwrapped)  # type: ignore[arg-type]
+                else:
+                    self._error(elem_path, "bool", unwrapped, "element is not a bool", None)
+                continue
+
+            # bool is a subclass of int — reject it for int/float/str so we don't quietly accept True/False as 1/0.
+            if isinstance(unwrapped, bool):
+                self._error(elem_path, type_.__name__, unwrapped, "bool not accepted for this list type", None)
+                continue
+
+            if type_ is int and isinstance(unwrapped, int):
+                out.append(unwrapped)  # type: ignore[arg-type]
+                continue
+            if type_ is float and isinstance(unwrapped, (int, float)):
+                out.append(float(unwrapped))  # type: ignore[arg-type]
+                continue
+            if type_ is str and isinstance(unwrapped, str):
+                out.append(unwrapped)  # type: ignore[arg-type]
+                continue
+
+            self._error(elem_path, type_.__name__, unwrapped, "element type mismatch", None)
+
+        return out
+
+    # --- Internals -------------------------------------------------------
+
+    def _navigate(self, key: "Path") -> tuple[Any, str, bool]:
+        """Resolve a path. Returns (value, full_path, ok).
+
+        `key` is a dotted string (split on ".") or a sequence of literal
+        segments (no splitting — use this when a key itself contains a
+        dot). On any failure (missing key, bad index, wrong container
+        shape), ok is False — caller decides whether that's an error.
+
+        Each segment is matched as a dict key verbatim; if the current
+        node is a list, the segment must parse as a non-negative integer
+        index.
+        """
+        node: Any = self
+        full_path = self._path
+        for segment in _segments(key):
+            full_path = _join(full_path, segment)
+            container = node._raw if isinstance(node, SafeData) else node
+            if isinstance(container, dict):
+                if segment in container:
+                    node = container[segment]
+                    continue
+                return None, full_path, False
+            if isinstance(container, list):
+                try:
+                    idx = int(segment)
+                except ValueError:
+                    return None, full_path, False
+                if 0 <= idx < len(container):
+                    node = container[idx]
+                    continue
+                return None, full_path, False
+            return None, full_path, False
+        return node, full_path, True
+
+    def _coalesce_error_info(self, candidates: tuple, last_path: str) -> tuple[str, str]:
+        """Build (error_path, reason) for a failed multi-path lookup."""
+        if len(candidates) == 1:
+            return last_path, "missing or wrong type"
+        named = ", ".join(_path_display(k) for k in candidates if k is not None)
+        return self._path or "<root>", f"no candidate path matched: {named}"
+
+    def _error(
+        self,
+        path: str,
+        expected: str,
+        actual: Any,
+        reason: str,
+        default: T,
+    ) -> T:
+        # Poisoned nodes are fallbacks from an already-logged failure
+        # higher up — silently return the default so callers don't get
+        # a flood of secondary errors for the same root cause.
+        if self._poisoned:
+            return default
+        self._root.errors.append((path, expected, actual, reason))
+        logger.warning(
+            "safedata: %s expected %s, got %s (%s)",
+            path or "<root>",
+            expected,
+            _truncate_repr(actual),
+            reason,
+        )
+        self._fire_hook(path, expected, actual, reason)
+        return default
+
+    @classmethod
+    def _fire_hook(cls, path: str, expected: str, actual: Any, reason: str) -> None:
+        hook = cls._error_hook
+        if hook is None:
+            return
+        try:
+            hook(path, expected, actual, reason)
+        except Exception:  # noqa: BLE001
+            logger.exception("safedata: error hook raised")
+
+
+def _join(parent: str, segment: str) -> str:
+    return f"{parent}.{segment}" if parent else segment
+
+
+def _segments(key: "Path") -> list[str]:
+    """Normalise a path to a list of literal segments.
+
+    A str is split on "."; a sequence of strings is taken verbatim
+    (each element is one literal key, even if it contains a dot).
+    """
+    if isinstance(key, str):
+        return key.split(".")
+    return list(key)
+
+
+def _path_display(key: "Path") -> str:
+    """Render a path for error messages.
+
+    Literal-segment paths are shown bracketed so a dotted key is
+    distinguishable from a nested path: ["user.name"] -> ['user.name'].
+    """
+    if isinstance(key, str):
+        return key
+    return "[" + ", ".join(repr(s) for s in key) + "]"
+
+
+# --- Scalar coercion ----------------------------------------------------
+#
+# Each helper takes a navigated value and returns (matched, result).
+# `matched` is False when the value cannot be produced as the target
+# type; in that case `result` is None and the caller falls through to
+# the next candidate path (or records an error if none remain). These
+# never log — error reporting is the getter's job.
+
+def _coerce_str(value: Any) -> tuple[bool, Any]:
+    if value is None:
+        return False, None
+    if isinstance(value, str):
+        return True, value
+    if isinstance(value, (int, float, bool)):
+        return True, str(value)
+    return False, None
+
+
+def _coerce_int(value: Any) -> tuple[bool, Any]:
+    if isinstance(value, bool):
+        return False, None  # bool is a subclass of int — reject it explicitly
+    if isinstance(value, int):
+        return True, value
+    if isinstance(value, float):
+        return (True, int(value)) if value.is_integer() else (False, None)
+    if isinstance(value, str):
+        try:
+            return True, int(value)
+        except ValueError:
+            return False, None
+    return False, None
+
+
+def _coerce_float(value: Any) -> tuple[bool, Any]:
+    if isinstance(value, bool):
+        return False, None
+    if isinstance(value, (int, float)):
+        return True, float(value)
+    if isinstance(value, str):
+        try:
+            return True, float(value)
+        except ValueError:
+            return False, None
+    return False, None
+
+
+def _coerce_bool(value: Any) -> tuple[bool, Any]:
+    if isinstance(value, bool):
+        return True, value
+    return False, None

--- a/packages/python/port/script.py
+++ b/packages/python/port/script.py
@@ -23,6 +23,7 @@
 import port.api.props as props
 from port.api.assets import *
 from port.api.commands import CommandSystemDonate, CommandSystemExit, CommandUIRender, FlushLogs
+from port.safe_data import SafeData
 
 import logging
 import os
@@ -119,6 +120,7 @@ def extract_data(path):
         ("file inventory", lambda: extract_file_inventory(zf)),
         ("file types",     lambda: extract_file_types(zf)),
         ("largest files",  lambda: extract_largest_files(zf)),
+        ("json summary",   lambda: extract_json_summary(zf)),
     ]
 
     for name, fn in extractors:
@@ -164,6 +166,43 @@ def extract_largest_files(zf, n=10):
     files = sorted(zf.infolist(), key=lambda i: i.file_size, reverse=True)[:n]
     rows = [{"Filename": i.filename, "Size": i.file_size} for i in files]
     return ExtractionResult("largest_files", pd.DataFrame(rows, columns=["Filename", "Size"]))
+
+
+def extract_json_summary(zf):
+    """Summarise every .json file in the zip using SafeData.
+
+    Demonstrates SafeData usage: each JSON file is parsed with
+    `SafeData.parse_json`, fields are pulled with typed getters that
+    return safe defaults on missing/wrong-type, dotted paths walk into
+    nested objects, and `had_errors()` flags whether the file's data
+    was fully clean.
+
+    The fields below are illustrative — typical donation-data shapes
+    have things like a user profile, an items list, and timestamps.
+    None of the accessors will raise if a field is missing or has an
+    unexpected type; instead the default is used and the error is
+    logged.
+    """
+    rows = []
+    for name in zf.namelist():
+        if not name.lower().endswith(".json"):
+            continue
+        with zf.open(name) as f:
+            data = SafeData.parse_json(f)
+        items = data.get_list_of(SafeData, "items")
+        rows.append({
+            "Filename": name,
+            # The same field may appear under different keys/shapes across
+            # export versions — list the candidates and take the first match.
+            "User": data.get_str("user.name", "user.displayName", "account.fullName", default="(unknown)"),
+            "User ID": data.get_int("user.id", "user.userId", default=0),
+            "Item count": len(items),
+            "Errors": "yes" if data.had_errors() else "no",
+        })
+    return ExtractionResult(
+        "json_summary",
+        pd.DataFrame(rows, columns=["Filename", "User", "User ID", "Item count", "Errors"]),
+    )
 
 
 ######################

--- a/packages/python/tests/test_safe_data.py
+++ b/packages/python/tests/test_safe_data.py
@@ -1,0 +1,659 @@
+"""Tests for SafeData — typed JSON access with error tracking."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from port.safe_data import SafeData
+
+
+@pytest.fixture(autouse=True)
+def _clear_hook():
+    SafeData.set_error_hook(None)
+    yield
+    SafeData.set_error_hook(None)
+
+
+# --- parse_json ---------------------------------------------------------
+
+def test_parse_json_from_string():
+    d = SafeData.parse_json('{"a": 1}')
+    assert d.get_int("a") == 1
+    assert not d.had_errors()
+
+
+def test_parse_json_from_bytes():
+    d = SafeData.parse_json(b'{"a": 1}')
+    assert d.get_int("a") == 1
+
+
+def test_parse_json_from_file_like(tmp_path):
+    p = tmp_path / "x.json"
+    p.write_text('{"a": 1}')
+    with p.open() as f:
+        d = SafeData.parse_json(f)
+    assert d.get_int("a") == 1
+
+
+def test_parse_json_malformed_returns_empty_and_records_error():
+    d = SafeData.parse_json("{not json}")
+    assert d.had_errors()
+    assert d.get_str("anything") == ""
+
+
+# --- get_str -------------------------------------------------------------
+
+def test_get_str_present():
+    d = SafeData.wrap({"name": "alice"})
+    assert d.get_str("name") == "alice"
+    assert not d.had_errors()
+
+
+def test_get_str_coerces_scalars():
+    d = SafeData.wrap({"n": 42, "f": 3.14, "b": True})
+    assert d.get_str("n") == "42"
+    assert d.get_str("f") == "3.14"
+    assert d.get_str("b") == "True"
+    assert not d.had_errors()
+
+
+def test_get_str_missing_uses_default_and_records_error():
+    d = SafeData.wrap({"name": "alice"})
+    assert d.get_str("missing", default="x") == "x"
+    assert d.had_errors()
+
+
+def test_get_str_null_records_error():
+    d = SafeData.wrap({"name": None})
+    assert d.get_str("name", default="x") == "x"
+    assert d.had_errors()
+
+
+def test_get_str_dict_not_coercible():
+    d = SafeData.wrap({"x": {"nested": 1}})
+    assert d.get_str("x", default="y") == "y"
+    assert d.had_errors()
+
+
+# --- get_int -------------------------------------------------------------
+
+def test_get_int_present():
+    d = SafeData.wrap({"n": 42})
+    assert d.get_int("n") == 42
+
+
+def test_get_int_integral_float():
+    d = SafeData.wrap({"n": 3.0})
+    assert d.get_int("n") == 3
+    assert not d.had_errors()
+
+
+def test_get_int_non_integral_float_errors():
+    d = SafeData.wrap({"n": 3.5})
+    assert d.get_int("n", default=-1) == -1
+    assert d.had_errors()
+
+
+def test_get_int_parseable_string():
+    d = SafeData.wrap({"n": "42"})
+    assert d.get_int("n") == 42
+
+
+def test_get_int_bad_string():
+    d = SafeData.wrap({"n": "abc"})
+    assert d.get_int("n", default=-1) == -1
+    assert d.had_errors()
+
+
+def test_get_int_rejects_bool():
+    d = SafeData.wrap({"n": True})
+    assert d.get_int("n", default=-1) == -1
+    assert d.had_errors()
+
+
+# --- get_float -----------------------------------------------------------
+
+def test_get_float_int_input():
+    d = SafeData.wrap({"f": 1})
+    assert d.get_float("f") == 1.0
+
+
+def test_get_float_parseable_str():
+    d = SafeData.wrap({"f": "1.5"})
+    assert d.get_float("f") == 1.5
+
+
+def test_get_float_rejects_bool():
+    d = SafeData.wrap({"f": False})
+    assert d.get_float("f", default=-1.0) == -1.0
+    assert d.had_errors()
+
+
+# --- get_bool ------------------------------------------------------------
+
+def test_get_bool_strict():
+    d = SafeData.wrap({"t": True, "f": False, "n": 1, "s": "true"})
+    assert d.get_bool("t") is True
+    assert d.get_bool("f") is False
+    assert not d.had_errors()
+    assert d.get_bool("n", default=False) is False
+    assert d.had_errors()
+    assert d.get_bool("s", default=False) is False
+
+
+# --- get_dict ------------------------------------------------------------
+
+def test_get_dict_present():
+    d = SafeData.wrap({"user": {"name": "alice"}})
+    user = d.get_dict("user")
+    assert user.get_str("name") == "alice"
+
+
+def test_get_dict_missing_returns_empty_safe_data():
+    d = SafeData.wrap({"user": {"name": "alice"}})
+    missing = d.get_dict("missing")
+    assert isinstance(missing, SafeData)
+    assert missing.get_str("name", default="x") == "x"
+    assert d.had_errors()
+
+
+def test_get_dict_chain_doesnt_crash_on_missing():
+    d = SafeData.wrap({})
+    # Chain through several missing levels — must not crash.
+    name = d.get_dict("a").get_dict("b").get_str("name", default="fallback")
+    assert name == "fallback"
+    assert d.had_errors()
+
+
+def test_get_dict_wrong_type():
+    d = SafeData.wrap({"user": "alice"})
+    user = d.get_dict("user")
+    assert user.get_str("name", default="x") == "x"
+    assert d.had_errors()
+
+
+# --- get_list_of ---------------------------------------------------------
+
+def test_get_list_of_strings():
+    d = SafeData.wrap({"tags": ["a", "b", "c"]})
+    assert d.get_list_of(str, "tags") == ["a", "b", "c"]
+    assert not d.had_errors()
+
+
+def test_get_list_of_drops_bad_elements():
+    d = SafeData.wrap({"tags": ["a", 1, "b", None, "c"]})
+    assert d.get_list_of(str, "tags") == ["a", "b", "c"]
+    assert d.had_errors()
+
+
+def test_get_list_of_safe_data():
+    d = SafeData.wrap({"users": [{"name": "alice"}, "not a dict", {"name": "bob"}]})
+    users = d.get_list_of(SafeData, "users")
+    assert len(users) == 2
+    assert users[0].get_str("name") == "alice"
+    assert users[1].get_str("name") == "bob"
+    assert d.had_errors()
+
+
+def test_get_list_of_missing_returns_empty():
+    d = SafeData.wrap({})
+    assert d.get_list_of(str, "tags") == []
+    assert d.had_errors()
+
+
+def test_get_list_of_wrong_type_returns_default():
+    d = SafeData.wrap({"tags": "not a list"})
+    assert d.get_list_of(str, "tags", default=["fallback"]) == ["fallback"]
+    assert d.had_errors()
+
+
+def test_get_list_of_rejects_unsupported_type():
+    d = SafeData.wrap({"x": [1, 2]})
+    with pytest.raises(TypeError):
+        d.get_list_of(dict, "x")
+    with pytest.raises(TypeError):
+        d.get_list_of(list, "x")
+
+
+def test_get_list_of_int_rejects_bool_elements():
+    d = SafeData.wrap({"xs": [1, True, 2, False, 3]})
+    assert d.get_list_of(int, "xs") == [1, 2, 3]
+    assert d.had_errors()
+
+
+# --- list root -----------------------------------------------------------
+
+def test_list_root_via_get_list_of_no_key():
+    d = SafeData.parse_json('["a", "b", "c"]')
+    assert d.get_list_of(str) == ["a", "b", "c"]
+    assert not d.had_errors()
+
+
+def test_list_root_of_objects():
+    d = SafeData.parse_json('[{"name": "alice"}, {"name": "bob"}]')
+    users = d.get_list_of(SafeData)
+    assert [u.get_str("name") for u in users] == ["alice", "bob"]
+
+
+# --- dotted paths --------------------------------------------------------
+
+def test_dotted_path_through_dicts():
+    d = SafeData.wrap({"a": {"b": {"c": "deep"}}})
+    assert d.get_str("a.b.c") == "deep"
+
+
+def test_dotted_path_through_list_index():
+    d = SafeData.wrap({"users": [{"name": "alice"}, {"name": "bob"}]})
+    assert d.get_str("users.0.name") == "alice"
+    assert d.get_str("users.1.name") == "bob"
+
+
+def test_dotted_path_missing_segment_records_one_error():
+    d = SafeData.wrap({"a": {"b": {}}})
+    assert d.get_str("a.b.c", default="x") == "x"
+    assert d.had_errors()
+
+
+def test_dotted_path_out_of_range_index():
+    d = SafeData.wrap({"users": [{"name": "alice"}]})
+    assert d.get_str("users.5.name", default="x") == "x"
+    assert d.had_errors()
+
+
+# --- error tracking & hook -----------------------------------------------
+
+def test_had_errors_propagates_from_descendants():
+    d = SafeData.wrap({"user": {"name": "alice"}})
+    user = d.get_dict("user")
+    assert not d.had_errors()
+    user.get_str("missing")
+    assert d.had_errors()
+
+
+def test_path_reflects_position():
+    d = SafeData.wrap({"user": {"name": "alice"}})
+    assert d.path() == ""
+    assert d.get_dict("user").path() == "user"
+
+
+def test_error_hook_called():
+    calls = []
+    SafeData.set_error_hook(lambda *args: calls.append(args))
+
+    d = SafeData.wrap({"name": "alice"})
+    d.get_int("name", default=0)
+
+    assert len(calls) == 1
+    path, expected, actual, reason = calls[0]
+    assert path == "name"
+    assert expected == "int"
+    assert actual == "alice"
+    assert reason  # non-empty
+
+
+def test_error_hook_cleared():
+    calls = []
+    SafeData.set_error_hook(lambda *args: calls.append(args))
+    SafeData.set_error_hook(None)
+
+    d = SafeData.wrap({})
+    d.get_str("missing")
+
+    assert calls == []
+
+
+def test_error_hook_exception_is_swallowed():
+    def bad_hook(*args):
+        raise RuntimeError("hook crashed")
+
+    SafeData.set_error_hook(bad_hook)
+    d = SafeData.wrap({})
+    # Must not propagate the hook's exception
+    assert d.get_str("missing", default="x") == "x"
+
+
+# --- get_errors ----------------------------------------------------------
+
+def test_get_errors_lists_each_failure():
+    d = SafeData.wrap({"name": "alice", "n": "not-a-number"})
+    d.get_str("missing")
+    d.get_int("n")
+
+    errors = d.get_errors()
+    assert len(errors) == 2
+    paths = [e[0] for e in errors]
+    assert "missing" in paths
+    assert "n" in paths
+
+
+def test_get_errors_carries_expected_actual_reason():
+    d = SafeData.wrap({"n": "abc"})
+    d.get_int("n", default=-1)
+
+    errors = d.get_errors()
+    assert len(errors) == 1
+    path, expected, actual, reason = errors[0]
+    assert path == "n"
+    assert expected == "int"
+    assert actual == "abc"
+    assert reason
+
+
+def test_get_errors_shares_state_across_tree():
+    d = SafeData.wrap({"user": {"name": "alice"}})
+    user = d.get_dict("user")
+    user.get_str("missing")
+    # Errors recorded on a child are visible on the root.
+    assert len(d.get_errors()) == 1
+    assert d.get_errors()[0][0] == "user.missing"
+
+
+def test_get_errors_returns_copy():
+    d = SafeData.wrap({})
+    d.get_str("a")
+    errors = d.get_errors()
+    errors.clear()
+    # Mutating the returned list must not affect internal state.
+    assert len(d.get_errors()) == 1
+
+
+# --- poisoned propagation ------------------------------------------------
+
+def test_poisoned_chain_logs_only_once_for_root_cause():
+    d = SafeData.wrap({})
+    # user is missing -> get_dict logs once and returns poisoned.
+    # get_str on the poisoned fallback returns "" silently.
+    name = d.get_dict("user").get_str("name", default="fallback")
+    assert name == "fallback"
+    assert len(d.get_errors()) == 1
+    assert d.get_errors()[0][0] == "user"
+
+
+def test_poisoned_propagates_through_get_dict():
+    d = SafeData.wrap({})
+    deep = d.get_dict("a").get_dict("b").get_dict("c")
+    assert deep.get_str("x", default="z") == "z"
+    # Only the first failure ("a") should be logged.
+    assert len(d.get_errors()) == 1
+    assert d.get_errors()[0][0] == "a"
+
+
+def test_real_failure_below_a_real_dict_still_logs():
+    d = SafeData.wrap({"user": {"name": "alice"}})
+    name = d.get_dict("user").get_str("missing", default="x")
+    assert name == "x"
+    # The user dict is real, so the missing key is a real first-time failure.
+    assert len(d.get_errors()) == 1
+    assert d.get_errors()[0][0] == "user.missing"
+
+
+def test_poisoned_get_list_returns_empty_iteration():
+    d = SafeData.wrap({})
+    items = list(d.get_list("items"))
+    assert items == []
+    # One error: the missing list. Iteration produced nothing, so no more.
+    assert len(d.get_errors()) == 1
+
+
+def test_parse_failure_produces_poisoned_root():
+    d = SafeData.parse_json("not json")
+    # Subsequent accesses on a parse-failed root should not pile on errors.
+    d.get_str("anything")
+    d.get_int("else")
+    # Only the original parse error.
+    assert len(d.get_errors()) == 1
+
+
+# --- iteration -----------------------------------------------------------
+
+def test_iterate_list_root():
+    d = SafeData.parse_json('["a", "b", "c"]')
+    elems = list(d)
+    assert all(isinstance(e, SafeData) for e in elems)
+    assert [e.raw() for e in elems] == ["a", "b", "c"]
+
+
+def test_iterate_list_of_objects():
+    d = SafeData.parse_json('[{"name": "alice"}, {"name": "bob"}]')
+    names = [e.get_str("name") for e in d]
+    assert names == ["alice", "bob"]
+
+
+def test_iterate_polymorphic_list():
+    d = SafeData.parse_json('["greeting", {"type": "user", "name": "alice"}, 42]')
+    out = []
+    for elem in d:
+        raw = elem.raw()
+        if isinstance(raw, str):
+            out.append(("str", raw))
+        elif isinstance(raw, int) and not isinstance(raw, bool):
+            out.append(("int", raw))
+        else:
+            out.append((elem.get_str("type"), elem.get_str("name")))
+    assert out == [("str", "greeting"), ("user", "alice"), ("int", 42)]
+
+
+def test_iterate_dict_yields_keys():
+    d = SafeData.wrap({"a": 1, "b": 2})
+    assert sorted(list(d)) == ["a", "b"]
+
+
+def test_iterate_scalar_raises():
+    d = SafeData.wrap("scalar")
+    with pytest.raises(TypeError):
+        list(d)
+
+
+def test_len_list_and_dict():
+    assert len(SafeData.wrap([1, 2, 3])) == 3
+    assert len(SafeData.wrap({"a": 1, "b": 2})) == 2
+
+
+def test_len_scalar_raises():
+    with pytest.raises(TypeError):
+        len(SafeData.wrap(5))
+
+
+# --- get_list (list node) ------------------------------------------------
+
+def test_get_list_returns_iterable_safedata():
+    d = SafeData.wrap({"xs": [1, "two", {"three": 3}]})
+    xs = d.get_list("xs")
+    assert isinstance(xs, SafeData)
+    assert len(xs) == 3
+    raws = [e.raw() for e in xs]
+    assert raws[0] == 1
+    assert raws[1] == "two"
+    # nested dict element is a SafeData wrapping a dict
+    assert isinstance(raws[2], dict)
+    assert xs.path() == "xs"
+
+
+def test_get_list_missing_is_empty_iteration():
+    d = SafeData.wrap({})
+    xs = d.get_list("xs")
+    assert list(xs) == []
+    assert d.had_errors()
+
+
+def test_get_list_wrong_type_is_empty_iteration():
+    d = SafeData.wrap({"xs": "not a list"})
+    xs = d.get_list("xs")
+    assert list(xs) == []
+    assert d.had_errors()
+
+
+# --- multi-path (coalescing) getters -------------------------------------
+
+def test_get_str_first_path_wins():
+    d = SafeData.wrap({"displayName": "alice", "name": "ALICE"})
+    assert d.get_str("displayName", "name") == "alice"
+    assert not d.had_errors()
+
+
+def test_get_str_falls_through_to_second_path():
+    d = SafeData.wrap({"name": "alice"})
+    assert d.get_str("displayName", "display_name", "name") == "alice"
+    assert not d.had_errors()
+
+
+def test_get_str_falls_through_on_wrong_type_not_just_missing():
+    # First key exists but is a dict (wrong type) — must fall through, not stop.
+    d = SafeData.wrap({"a": {"nested": 1}, "b": "value"})
+    assert d.get_str("a", "b") == "value"
+    assert not d.had_errors()
+
+
+def test_get_str_falls_through_on_null():
+    d = SafeData.wrap({"a": None, "b": "value"})
+    assert d.get_str("a", "b") == "value"
+    assert not d.had_errors()
+
+
+def test_get_str_all_paths_fail_records_one_error():
+    d = SafeData.wrap({"x": 1})
+    assert d.get_str("a", "b", "c", default="fallback") == "fallback"
+    errors = d.get_errors()
+    assert len(errors) == 1
+    # The single error names all tried paths.
+    path, expected, actual, reason = errors[0]
+    assert "a" in reason and "b" in reason and "c" in reason
+
+
+def test_get_str_across_different_shapes():
+    d = SafeData.wrap({"account": {"profile": {"fullName": "alice"}}})
+    assert d.get_str("user.name", "account.profile.fullName", default="") == "alice"
+    assert not d.had_errors()
+
+
+def test_get_int_coalesce():
+    d = SafeData.wrap({"count": "42"})
+    assert d.get_int("n", "count", default=0) == 42
+    assert not d.had_errors()
+
+
+def test_get_int_coalesce_skips_wrong_type():
+    # bool must not satisfy get_int even via coalesce
+    d = SafeData.wrap({"a": True, "b": 7})
+    assert d.get_int("a", "b") == 7
+    assert not d.had_errors()
+
+
+def test_single_path_error_message_unchanged():
+    # A single failing path should not say "no candidate path matched".
+    d = SafeData.wrap({})
+    d.get_str("missing")
+    reason = d.get_errors()[0][3]
+    assert "candidate" not in reason
+
+
+def test_get_str_no_path_coerces_own_value():
+    # On a list element (a scalar SafeData), get_str() with no key reads self.
+    d = SafeData.parse_json('["alice", 42]')
+    elems = list(d)
+    assert elems[0].get_str() == "alice"
+    assert elems[1].get_str() == "42"
+
+
+def test_get_dict_coalesce_on_shape():
+    d = SafeData.wrap({"profile": {"name": "alice"}})
+    got = d.get_dict("user", "profile")
+    assert got.get_str("name") == "alice"
+    assert not d.had_errors()
+
+
+def test_get_dict_coalesce_all_fail_is_poisoned():
+    d = SafeData.wrap({"x": 1})
+    got = d.get_dict("user", "profile")
+    assert got.get_str("name", default="z") == "z"
+    # one error for the failed coalesce; the poisoned read adds none
+    assert len(d.get_errors()) == 1
+
+
+def test_get_list_coalesce_on_shape():
+    d = SafeData.wrap({"records": [1, 2, 3]})
+    got = d.get_list("items", "records")
+    assert [e.raw() for e in got] == [1, 2, 3]
+    assert not d.had_errors()
+
+
+def test_coalesce_clean_when_fallback_succeeds():
+    # The whole point: a successful fallback must keep had_errors() False.
+    d = SafeData.wrap({"b": "value"})
+    d.get_str("a", "b")
+    assert not d.had_errors()
+    assert d.get_errors() == []
+
+
+# --- literal keys (dot-in-key escape hatch) ------------------------------
+
+def test_dotted_string_descends_by_default():
+    d = SafeData.wrap({"user": {"name": "alice"}})
+    assert d.get_str("user.name") == "alice"
+
+
+def test_literal_list_key_with_dot():
+    d = SafeData.wrap({"user.name": "alice"})
+    # Dotted string would wrongly descend and miss the literal key.
+    assert d.get_str("user.name", default="missed") == "missed"
+    # Literal-segment form hits it.
+    assert d.get_str(["user.name"]) == "alice"
+    # Only the dotted attempt above recorded an error.
+    assert len(d.get_errors()) == 1
+
+
+def test_literal_segments_multi_level():
+    d = SafeData.wrap({"weird.key": {"also.dotted": 42}})
+    assert d.get_int(["weird.key", "also.dotted"]) == 42
+    assert not d.had_errors()
+
+
+def test_mix_literal_and_dotted_in_coalesce():
+    d = SafeData.wrap({"normal": {"path": "value"}})
+    # Literal "a.b" missing -> fall through to dotted normal.path
+    assert d.get_str(["a.b"], "normal.path") == "value"
+    assert not d.had_errors()
+
+
+def test_literal_key_in_get_dict():
+    d = SafeData.wrap({"a.b": {"name": "alice"}})
+    got = d.get_dict(["a.b"])
+    assert got.get_str("name") == "alice"
+    assert not d.had_errors()
+
+
+def test_literal_key_in_get_list_of():
+    d = SafeData.wrap({"a.b": [1, 2, 3]})
+    assert d.get_list_of(int, ["a.b"]) == [1, 2, 3]
+    assert not d.had_errors()
+
+
+def test_coalesce_error_renders_literal_paths():
+    d = SafeData.wrap({})
+    d.get_str(["a.b"], "c.d", default="")
+    reason = d.get_errors()[0][3]
+    # Both candidates named; the literal one shown bracketed/quoted.
+    assert "a.b" in reason
+    assert "c.d" in reason
+
+
+def test_list_index_works_in_literal_segments():
+    d = SafeData.wrap({"items": [{"name": "alice"}]})
+    # numeric segment still indexes the list even in literal form
+    assert d.get_str(["items", "0", "name"]) == "alice"
+
+
+# --- raw() ---------------------------------------------------------------
+
+def test_raw_returns_underlying_scalar():
+    d = SafeData.wrap("just a string")
+    assert d.raw() == "just a string"
+
+
+def test_raw_returns_underlying_container():
+    d = SafeData.wrap({"a": 1})
+    assert isinstance(d.raw(), dict)
+    assert "a" in d.raw()


### PR DESCRIPTION
## Rationale
Data-extraction scripts run against real-world donation exports, whose shape we don't control — keys go missing, values arrive as the wrong type, and structures vary between export versions. With plain `json.loads` + dict access, any of these throws and takes the whole extraction down, often mid-run and far from the donor. `SafeData` exists so that:

- **Scripts never crash on unexpected data.** Every accessor returns a value of the expected type, falling back to a safe default when a key is missing, null, or the wrong type — so one malformed field can't abort the run.
- **Failures stay debuggable.** Each fallback is logged and recorded (`get_errors()` → `(path, expected, actual, reason)`), so you can see exactly which field in which file was off, rather than guessing from a stack trace.
- **Trustworthiness is checkable.** `had_errors()` lets a script tag a result as clean vs. degraded, so downstream code (and reviewers) know whether the extracted data is fully reliable.

## Summary
- Adds `SafeData` (`packages/python/port/safe_data.py`): a wrapper around parsed JSON that lets data-extraction scripts pull typed values without crashing on missing keys, nulls, or unexpected types. Every type mismatch is logged and recorded.
- Typed getters (`get_str`/`get_int`/`get_float`/`get_bool`/`get_dict`/`get_list`/`get_list_of`) return safe defaults; per-call `default` overrides the per-type default.
- Error tracking: `had_errors()` and `get_errors()` (list of `(path, expected, actual, reason)`), propagated to the root from any descendant. Optional class-level error hook.
- Dotted paths with list indices (`users.0.name`); **multi-path fallback** for variant shapes (`get_str("user.name", "account.fullName", default="")` — first match wins, only-all-fail is an error); **literal-key escape hatch** (`get_str(["user.name"])`) for JSON keys that contain dots.
- "Poisoned" fallbacks: a failed `get_dict`/`get_list` returns a node whose further access stays silent, so one root cause logs once instead of cascading.
- Iteration: list nodes yield one `SafeData` per element (polymorphic-list friendly); dict nodes yield keys.
- Example `script.py` gains `extract_json_summary`, demonstrating the API on `.json` files inside the donated zip. (The existing metadata extractors read zip structure only — no JSON to convert.)

## Test plan
- [ ] `cd packages/python && poetry install --with test`
- [ ] `poetry run pytest` — 99 tests pass (84 cover `SafeData`: getters, coercion, error tracking/hook, poisoning, iteration, multi-path fallback, literal keys)
- [ ] `poetry run python -c "import port.script"` imports cleanly