### PR TITLE
Route locale from JS to Python via port.start(context)

### DIFF
--- a/packages/data-collector/public/py_worker.js
+++ b/packages/data-collector/public/py_worker.js
@@ -13,7 +13,7 @@ onmessage = (event) => {
       break;
 
     case "firstRunCycle":
-      pyScript = self.pyodide.runPython(`port.start(${event.data.sessionId})`);
+      pyScript = self.pyodide.runPython(`port.start(${JSON.stringify(event.data.data)})`);
       runCycle(null);
       break;
 

--- a/packages/feldspar/src/components/script_host_component.tsx
+++ b/packages/feldspar/src/components/script_host_component.tsx
@@ -40,7 +40,7 @@ const FeldsparContent: React.FC<ScriptHostProps> = ({
     workerRef.current = worker;
 
     const run = (bridge: Bridge, selectedLocale: string = locale) => {
-      const assembly = new Assembly(worker, bridge, factories, logLevel);
+      const assembly = new Assembly(worker, bridge, selectedLocale, factories, logLevel);
       assembly.visualizationEngine.start(
         containerRef.current!,
         selectedLocale,

--- a/packages/feldspar/src/framework/assembly.ts
+++ b/packages/feldspar/src/framework/assembly.ts
@@ -13,13 +13,13 @@ export default class Assembly {
   logForwarder: LogForwarder
   windowLogSource: WindowLogSource
 
-  constructor(worker: Worker, bridge: Bridge, factories: PageFactory[] = [], logLevel: LogLevel = 'warn') {
+  constructor(worker: Worker, bridge: Bridge, locale: string = "en", factories: PageFactory[] = [], logLevel: LogLevel = 'warn') {
     const sessionId = String(Date.now())
     const visualizationFactory = new ReactFactory(factories);
     this.visualizationEngine = new ReactEngine(visualizationFactory);
     this.router = new CommandRouter(bridge, this.visualizationEngine)
     this.logForwarder = new LogForwarder((entries) => bridge.sendLogs(entries), logLevel)
     this.windowLogSource = new WindowLogSource(this.logForwarder)
-    this.processingEngine = new WorkerProcessingEngine(sessionId, worker, this.router, this.logForwarder)
+    this.processingEngine = new WorkerProcessingEngine(sessionId, locale, worker, this.router, this.logForwarder)
   }
 }

--- a/packages/feldspar/src/framework/processing/worker_engine.test.ts
+++ b/packages/feldspar/src/framework/processing/worker_engine.test.ts
@@ -33,7 +33,7 @@ class FakeHandler implements CommandHandler {
 function makeEngine (): { engine: WorkerProcessingEngine, logger: FakeLogger, worker: FakeWorker } {
   const worker = new FakeWorker()
   const logger = new FakeLogger()
-  const engine = new WorkerProcessingEngine('s1', worker as unknown as Worker, new FakeHandler(), logger)
+  const engine = new WorkerProcessingEngine('s1', 'en', worker as unknown as Worker, new FakeHandler(), logger)
   return { engine, logger, worker }
 }
 

--- a/packages/feldspar/src/framework/processing/worker_engine.ts
+++ b/packages/feldspar/src/framework/processing/worker_engine.ts
@@ -10,6 +10,7 @@ function toLogLevel (value: unknown): LogLevel {
 
 export default class WorkerProcessingEngine {
   sessionId: String
+  locale: String
   worker: Worker
   commandHandler: CommandHandler
   logger?: Logger
@@ -19,11 +20,13 @@ export default class WorkerProcessingEngine {
 
   constructor (
     sessionId: string,
+    locale: string,
     worker: Worker,
     commandHandler: CommandHandler,
     logger?: Logger
   ) {
     this.sessionId = sessionId
+    this.locale = locale
     this.commandHandler = commandHandler
     this.worker = worker
     this.logger = logger
@@ -101,7 +104,10 @@ export default class WorkerProcessingEngine {
   }
 
   firstRunCycle (): void {
-    this.worker.postMessage({ eventType: 'firstRunCycle', sessionId: this.sessionId })
+    this.worker.postMessage({
+      eventType: 'firstRunCycle',
+      data: { sessionId: this.sessionId, locale: this.locale }
+    })
   }
 
   nextRunCycle (response: Response): void {

--- a/packages/python/port/main.py
+++ b/packages/python/port/main.py
@@ -48,8 +48,8 @@ class ScriptWrapper(Generator):
         raise StopIteration
 
 
-def start(sessionId):
-    script = process(sessionId)
+def start(data):
+    script = process(data)
     wrapper = ScriptWrapper(script)
     wrapper.add_log_handler()
     return wrapper

--- a/packages/python/port/script.py
+++ b/packages/python/port/script.py
@@ -41,8 +41,14 @@ ExtractionResult = namedtuple("ExtractionResult", ["name", "data_frame"])
 # Data donation flow #
 ######################
 
-def process(sessionId):
-    logger.info("user entered script")
+def process(data):
+    # `data` is a context dict routed from the JS framework:
+    #   {"sessionId": "...", "locale": "en" | "nl" | ...}
+    # Use `locale` for strings rendered into DataFrame cells (column headers,
+    # summary descriptions) — those bypass the React i18n layer.
+    sessionId = data.get("sessionId")
+    locale = data.get("locale", "en")
+    logger.info(f"user entered script (locale={locale})")
     key = "zip-contents-example"
 
     results = None
@@ -52,7 +58,7 @@ def process(sessionId):
         if fileResult is None:
             break
 
-        results, retry = yield from step_2_extract_data_from_file(key, fileResult)
+        results, retry = yield from step_2_extract_data_from_file(key, fileResult, locale)
         if retry:
             continue
         break
@@ -70,11 +76,11 @@ def step_1_select_file(key):
     return fileResult
 
 
-def step_2_extract_data_from_file(key, fileResult):
+def step_2_extract_data_from_file(key, fileResult, locale="en"):
     logger.debug(f"{key}: extracting file")
     results = None
     try:
-        results = yield from extract_data(fileResult.value)
+        results = yield from extract_data(fileResult.value, locale)
     except (IOError, zipfile.BadZipFile):
         logger.debug(f"{key}: prompt confirmation to retry file selection")
         retry_result = yield render_data_submission_page(retry_confirmation())
@@ -102,13 +108,13 @@ def step_3_consent(key, sessionId, results):
 # Zip file processing    #
 ##########################
 
-def extract_data(path):
+def extract_data(path, locale="en"):
     """Generator that runs extraction steps, returning the results list.
 
     Yields FlushLogs between steps so progress logs reach the client in real
     time rather than all at once when the consent page renders. Call via:
 
-        results = yield from extract_data(path)
+        results = yield from extract_data(path, locale)
     """
     logger.info("extract_data: opening zip file")
     zf = zipfile.ZipFile(path)
@@ -116,7 +122,7 @@ def extract_data(path):
     results = []
 
     extractors = [
-        ("file inventory", lambda: extract_file_inventory(zf)),
+        ("file inventory", lambda: extract_file_inventory(zf, locale)),
         ("file types",     lambda: extract_file_types(zf)),
         ("largest files",  lambda: extract_largest_files(zf)),
     ]
@@ -135,17 +141,34 @@ def extract_data(path):
     return results
 
 
-def extract_file_inventory(zf):
-    """List every file in the zip with its compressed and uncompressed size."""
+FILE_INVENTORY_HEADERS = {
+    "en": ["Filename", "Compressed size", "Size"],
+    "de": ["Dateiname", "Komprimierte Größe", "Größe"],
+    "it": ["Nome file", "Dimensione compressa", "Dimensione"],
+    "es": ["Nombre de archivo", "Tamaño comprimido", "Tamaño"],
+    "nl": ["Bestandsnaam", "Gecomprimeerde grootte", "Grootte"],
+    "ro": ["Nume fișier", "Dimensiune comprimată", "Dimensiune"],
+    "lt": ["Failo pavadinimas", "Suspaustas dydis", "Dydis"],
+}
+
+
+def extract_file_inventory(zf, locale="en"):
+    """List every file in the zip with its compressed and uncompressed size.
+
+    Column headers are localized via `locale` — this demonstrates threading the
+    UI locale into DataFrame content, which bypasses the React i18n layer.
+    """
+    headers = FILE_INVENTORY_HEADERS.get(locale, FILE_INVENTORY_HEADERS["en"])
+    filename_col, compressed_col, size_col = headers
     rows = []
     for info in zf.infolist():
         time.sleep(0.01)  # artificial delay — remove in production
         rows.append({
-            "Filename": info.filename,
-            "Compressed size": info.compress_size,
-            "Size": info.file_size,
+            filename_col: info.filename,
+            compressed_col: info.compress_size,
+            size_col: info.file_size,
         })
-    return ExtractionResult("file_inventory", pd.DataFrame(rows, columns=["Filename", "Compressed size", "Size"]))
+    return ExtractionResult("file_inventory", pd.DataFrame(rows, columns=headers))
 
 
 def extract_file_types(zf):

--- a/packages/python/port/script_custom_ui.py
+++ b/packages/python/port/script_custom_ui.py
@@ -27,7 +27,10 @@ import json
 import time
 
 
-def process(sessionId):
+def process(data):
+    # `data` is a context dict from the JS framework:
+    #   {"sessionId": "...", "locale": "en" | "nl" | ...}
+    sessionId = data.get("sessionId")
     key = "zip-contents-example"
     meta_data = []
     meta_data.append(("debug", f"{key}: start"))


### PR DESCRIPTION
## Summary
- Threads `locale` from `ScriptHostComponent` prop through `Assembly` and `WorkerProcessingEngine` into the `firstRunCycle` postMessage
- Changes `port.start(sessionId)` into `port.start(data)` where `data` is a `{ sessionId, locale }` context dict — extensible for future flags without further breaking changes
- Demonstrates the feature in `script.py` by localizing the `file_inventory` DataFrame column headers (en/de/it/es/nl/ro/lt) — a strings-in-DataFrame-cells case the React i18n layer can't reach

Fixes [FX#10014268434](https://3.basecamp.com/4390246/buckets/36111585/todos/10014268434).

## Why
Cambridge donation forks (2025-cambridge-tiktok, 2025-cambridge-instagram) currently maintain a 5-file Feldspar delta on every upstream sync to thread `locale` into Python for DataFrame column headers and summary descriptions. Re-applying those edits is fragile — the 2026-06-19 sync missed a call site and the donation flow rendered a blank page because `process(data)` received a bare int. This makes locale a first-class input so forks can drop the delta.

## Files
- `packages/feldspar/src/components/script_host_component.tsx` — pass `selectedLocale` to `Assembly`
- `packages/feldspar/src/framework/assembly.ts` — accept `locale`, forward to `WorkerProcessingEngine`
- `packages/feldspar/src/framework/processing/worker_engine.ts` — store `locale`, `firstRunCycle` posts `data: { sessionId, locale }`
- `packages/feldspar/src/framework/processing/worker_engine.test.ts` — updated for new positional arg
- `packages/data-collector/public/py_worker.js` — `port.start(${JSON.stringify(event.data.data)})`
- `packages/python/port/main.py` — `start(data)` forwards dict to `process(data)`
- `packages/python/port/script.py` — `process(data)` reads `sessionId`/`locale`; localized `file_inventory` headers
- `packages/python/port/script_custom_ui.py` — matching signature update

## Test plan
- [x] Jest unit tests pass (12/12)
- [x] pytest tests pass (15/15)
- [x] Playwright e2e tests pass (5/5)
- [x] Manual smoke: browser log shows `user entered script (locale=en)`, proving JS→Python wiring
- [ ] Manual verification with non-default locale (e.g. wire `locale="nl"` in a consumer and confirm localized DataFrame headers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)